### PR TITLE
support extended components

### DIFF
--- a/example/next-app-router/src/app/page.tsx
+++ b/example/next-app-router/src/app/page.tsx
@@ -41,6 +41,7 @@ export default function Home() {
       </div>
       <StyledFn>styled fn</StyledFn>
       <StyledProperty>styled property</StyledProperty>
+      <StyledExtended>styled extended</StyledExtended>
     </div>
   );
 }
@@ -49,6 +50,10 @@ const StyledFn = styled("div")`
   background-color: lightblue;
 `;
 
-const StyledProperty = styled.div`
+const StyledProperty = styled.button`
   background-color: cyan;
 `;
+
+const StyledExtended = styled(StyledProperty)`
+  color: orange;
+`

--- a/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
@@ -45,7 +45,7 @@ const GreenButton = props => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
     };
-const GreenButtonRedTest = props => {
+const GreenButtonRedText = props => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
       return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
     };
@@ -138,7 +138,7 @@ const GreenButton = props => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
     };
-const GreenButtonRedTest = props => {
+const GreenButtonRedText = props => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
       return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
     };
@@ -231,7 +231,7 @@ const GreenButton = props => {
       const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
       return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
     };
-const GreenButtonRedTest = props => {
+const GreenButtonRedText = props => {
       const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
       return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
     };

--- a/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
@@ -34,6 +34,27 @@ function App() {
 "
 `;
 
+exports[`styled function > Snapshot tests (runtime: automatic) > 'styled' tag property usage should match snapshot 2`] = `
+"
+.🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
+
+import { Box as __Box } from \\"@kuma-ui/core\\";
+import React from \\"react\\";
+import { styled } from '@kuma-ui/core';
+const GreenButton = props => {
+      const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
+      return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+    };
+const GreenButtonRedTest = props => {
+      const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
+      return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+    };
+function App() {
+  return <GreenButton>test</GreenButton>;
+}
+"
+`;
+
 exports[`styled function > Snapshot tests (runtime: automatic) > using className prop should match snapshot 1`] = `
 "
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
@@ -106,6 +127,27 @@ function App() {
 "
 `;
 
+exports[`styled function > Snapshot tests (runtime: classic) > 'styled' tag property usage should match snapshot 2`] = `
+"
+.🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
+
+import { Box as __Box } from \\"@kuma-ui/core\\";
+import React from \\"react\\";
+import { styled } from '@kuma-ui/core';
+const GreenButton = props => {
+      const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
+      return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+    };
+const GreenButtonRedTest = props => {
+      const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
+      return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+    };
+function App() {
+  return <GreenButton>test</GreenButton>;
+}
+"
+`;
+
 exports[`styled function > Snapshot tests (runtime: classic) > using className prop should match snapshot 1`] = `
 "
 .🐻-101236145{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.🐻-101236145:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.🐻-101236145{flex-direction:column;}}
@@ -174,6 +216,27 @@ const Box = props => {
     };
 function App() {
   return <Box>test</Box>;
+}
+"
+`;
+
+exports[`styled function > Snapshot tests (runtime: undefined) > 'styled' tag property usage should match snapshot 2`] = `
+"
+.🐻-3239996223{background:green;}.🐻-1641059616{color:red;}
+
+import { Box as __Box } from \\"@kuma-ui/core\\";
+import React from \\"react\\";
+import { styled } from '@kuma-ui/core';
+const GreenButton = props => {
+      const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
+      return <__Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+    };
+const GreenButtonRedTest = props => {
+      const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
+      return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+    };
+function App() {
+  return <GreenButton>test</GreenButton>;
 }
 "
 `;

--- a/packages/babel-plugin/src/__test__/styled.test.ts
+++ b/packages/babel-plugin/src/__test__/styled.test.ts
@@ -77,7 +77,7 @@ describe("styled function", () => {
         const GreenButton = styled.button\`
           background: green;
         \`
-        const GreenButtonRedTest = styled(GreenButton)\`
+        const GreenButtonRedText = styled(GreenButton)\`
           color: red;
         \`
         function App() {

--- a/packages/babel-plugin/src/__test__/styled.test.ts
+++ b/packages/babel-plugin/src/__test__/styled.test.ts
@@ -70,6 +70,26 @@ describe("styled function", () => {
         expect(getExpectSnapshot(result)).toMatchSnapshot();
       });
 
+      test("'styled' tag property usage should match snapshot", () => {
+        // Arrange
+        const inputCode = `
+        import { styled } from '@kuma-ui/core'
+        const GreenButton = styled.button\`
+          background: green;
+        \`
+        const GreenButtonRedTest = styled(GreenButton)\`
+          color: red;
+        \`
+        function App() {
+          return <GreenButton>test</GreenButton>
+        }
+      `;
+        // Act
+        const result = babelTransform(inputCode);
+        // Assert
+        expect(getExpectSnapshot(result)).toMatchSnapshot();
+      });
+
       test("placeholder usage should match snapshot", () => {
         const originalCode = `
         import { styled } from '@kuma-ui/core'

--- a/packages/compiler/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/compiler/src/__test__/__snapshots__/styled.test.ts.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`styled tag > should generate code 1`] = `
+"
+  
+  
+  
+        import { styled } from \\"@kuma-ui/core\\";
+        
+        export const GreenButton = props => {
+              const combinedClassName = [props.className, \\"🐻-3239996223\\"].filter(Boolean).join(\\" \\");
+              return <Box as=\\"button\\" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+            }
+        export const GreenButtonRedText = props => {
+              const combinedClassName = [props.className, \\"🐻-1641059616\\"].filter(Boolean).join(\\" \\");
+              return <GreenButton {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+            }
+    
+  "
+`;

--- a/packages/compiler/src/__test__/styled.test.ts
+++ b/packages/compiler/src/__test__/styled.test.ts
@@ -1,0 +1,28 @@
+import { compile } from "../compile";
+import { getExpectSnapshot } from "./testUtils";
+import { describe, it, expect } from "vitest";
+import { componentList } from "@kuma-ui/core/components/componentList";
+
+describe("styled tag", () => {
+  it("should generate code", () => {
+    // Arrange
+    const code = `
+        import { styled } from "@kuma-ui/core";
+        
+        export const GreenButton = styled.button\`
+          background: green;
+        \`
+        export const GreenButtonRedText = styled(GreenButton)\`
+          color: red;
+        \`
+    `;
+
+    // Act
+    const result = compile(code, "file.tsx", {
+        ...componentList,
+        styled: 'styled',
+    });
+    // Assert
+    expect(getExpectSnapshot(result)).toMatchSnapshot();
+  });
+});

--- a/packages/compiler/src/__test__/styled.test.ts
+++ b/packages/compiler/src/__test__/styled.test.ts
@@ -19,8 +19,8 @@ describe("styled tag", () => {
 
     // Act
     const result = compile(code, "file.tsx", {
-        ...componentList,
-        styled: 'styled',
+      ...componentList,
+      styled: "styled",
     });
     // Assert
     expect(getExpectSnapshot(result)).toMatchSnapshot();

--- a/packages/compiler/src/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processTaggedTemplateExpression.ts
@@ -33,28 +33,36 @@ export const processTaggedTemplateExpression = (
       bindings["styled"]
   ) {
     const componentArg = tag.getArguments()[0];
-    console.log(node.getFullText(), componentArg, Node.isStringLiteral(componentArg))
+    console.log(
+      node.getFullText(),
+      componentArg,
+      Node.isStringLiteral(componentArg)
+    );
     if (Node.isStringLiteral(componentArg)) {
-      const componentName = componentArg.getLiteralText()
-      replaceTaggedTemplate(node, getBoxComponent(componentName, bindings))
+      const componentName = componentArg.getLiteralText();
+      replaceTaggedTemplate(node, getBoxComponent(componentName, bindings));
     } else {
-      replaceTaggedTemplate(node, componentArg.getFullText())
+      replaceTaggedTemplate(node, componentArg.getFullText());
     }
   }
 
   // styled.xxx``
-  else if (
-    Node.isPropertyAccessExpression(tag)
-  ) {
-    replaceTaggedTemplate(node, getBoxComponent(tag.getName(), bindings))
+  else if (Node.isPropertyAccessExpression(tag)) {
+    replaceTaggedTemplate(node, getBoxComponent(tag.getName(), bindings));
   }
 };
 
-function getBoxComponent(intrinsicComponentName: string, bindings: Record<string, string>) {
-  return `${bindings["Box"]} as="${intrinsicComponentName}"`
+function getBoxComponent(
+  intrinsicComponentName: string,
+  bindings: Record<string, string>
+) {
+  return `${bindings["Box"]} as="${intrinsicComponentName}"`;
 }
 
-function replaceTaggedTemplate(node: TaggedTemplateExpression, component: string) {
+function replaceTaggedTemplate(
+  node: TaggedTemplateExpression,
+  component: string
+) {
   const className = extractClassName(node.getTemplate());
   if (className) {
     const replacement = `props => {

--- a/packages/compiler/src/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processTaggedTemplateExpression.ts
@@ -26,33 +26,40 @@ export const processTaggedTemplateExpression = (
       node.replaceWithText(JSON.stringify(className));
     }
   }
-  // styled("xxx")``
+  // styled("xxx")`` or styled(AnotherComponent)``
   else if (
     Node.isCallExpression(tag) &&
     tag.getExpressionIfKind(SyntaxKind.Identifier)?.getText() ===
       bindings["styled"]
   ) {
     const componentArg = tag.getArguments()[0];
-    const component = Node.isStringLiteral(componentArg)
-      ? componentArg.getLiteralText()
-      : "div";
-    replaceTaggedTemplate(node, component, bindings);
+    console.log(node.getFullText(), componentArg, Node.isStringLiteral(componentArg))
+    if (Node.isStringLiteral(componentArg)) {
+      const componentName = componentArg.getLiteralText()
+      replaceTaggedTemplate(node, getBoxComponent(componentName, bindings))
+    } else {
+      replaceTaggedTemplate(node, componentArg.getFullText())
+    }
   }
 
   // styled.xxx``
   else if (
     Node.isPropertyAccessExpression(tag)
   ) {
-    replaceTaggedTemplate(node, tag.getName(), bindings)
+    replaceTaggedTemplate(node, getBoxComponent(tag.getName(), bindings))
   }
 };
 
-function replaceTaggedTemplate(node: TaggedTemplateExpression, component: string, bindings: Record<string, string>) {
+function getBoxComponent(intrinsicComponentName: string, bindings: Record<string, string>) {
+  return `${bindings["Box"]} as="${intrinsicComponentName}"`
+}
+
+function replaceTaggedTemplate(node: TaggedTemplateExpression, component: string) {
   const className = extractClassName(node.getTemplate());
   if (className) {
     const replacement = `props => {
       const combinedClassName = [props.className, "${className}"].filter(Boolean).join(" ");
-      return <${bindings["Box"]} as="${component}" {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
+      return <${component} {...props} className={combinedClassName} IS_KUMA_DEFAULT />;
     }`;
     node.replaceWithText(replacement);
   }

--- a/packages/core/src/styled.ts
+++ b/packages/core/src/styled.ts
@@ -12,9 +12,16 @@ export type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
   ? P
   : never;
 
-export type StyleTemplate<T extends keyof JSX.IntrinsicElements> = (strings: TemplateStringsArray) => React.FC<React.ComponentProps<T>>
+export type StyledComponent<T extends keyof JSX.IntrinsicElements> = React.FC<React.ComponentProps<T>>
 
-function _styled<T extends keyof JSX.IntrinsicElements>(Component: T) {
+export type StyleTemplate<T extends keyof JSX.IntrinsicElements> = (strings: TemplateStringsArray) => StyledComponent<T>
+
+export type StyledFn = {
+  <T extends keyof JSX.IntrinsicElements>(name: T): StyleTemplate<T>
+  <T extends keyof JSX.IntrinsicElements>(Component: StyledComponent<T>): StyleTemplate<T>
+}
+
+function _styled<T extends keyof JSX.IntrinsicElements>(Component: T | StyledComponent<T>) {
   const fn: StyleTemplate<T> = (strings) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
     throw Error('Using the "styled" tag in runtime is not supported.') as any;
@@ -28,7 +35,7 @@ const styled = new Proxy(_styled, {
   get(target, key) {
     return target(key as keyof JSX.IntrinsicElements)
   }
-}) as typeof _styled & {
+}) as StyledFn & {
   [T in keyof JSX.IntrinsicElements]: StyleTemplate<T>
 }
 

--- a/packages/core/src/styled.ts
+++ b/packages/core/src/styled.ts
@@ -12,16 +12,24 @@ export type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
   ? P
   : never;
 
-export type StyledComponent<T extends keyof JSX.IntrinsicElements> = React.FC<React.ComponentProps<T>>
+export type StyledComponent<T extends keyof JSX.IntrinsicElements> = React.FC<
+  React.ComponentProps<T>
+>;
 
-export type StyleTemplate<T extends keyof JSX.IntrinsicElements> = (strings: TemplateStringsArray) => StyledComponent<T>
+export type StyleTemplate<T extends keyof JSX.IntrinsicElements> = (
+  strings: TemplateStringsArray
+) => StyledComponent<T>;
 
 export type StyledFn = {
-  <T extends keyof JSX.IntrinsicElements>(name: T): StyleTemplate<T>
-  <T extends keyof JSX.IntrinsicElements>(Component: StyledComponent<T>): StyleTemplate<T>
-}
+  <T extends keyof JSX.IntrinsicElements>(name: T): StyleTemplate<T>;
+  <T extends keyof JSX.IntrinsicElements>(
+    Component: StyledComponent<T>
+  ): StyleTemplate<T>;
+};
 
-function _styled<T extends keyof JSX.IntrinsicElements>(Component: T | StyledComponent<T>) {
+function _styled<T extends keyof JSX.IntrinsicElements>(
+  Component: T | StyledComponent<T>
+) {
   const fn: StyleTemplate<T> = (strings) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
     throw Error('Using the "styled" tag in runtime is not supported.') as any;
@@ -33,10 +41,10 @@ function _styled<T extends keyof JSX.IntrinsicElements>(Component: T | StyledCom
  */
 const styled = new Proxy(_styled, {
   get(target, key) {
-    return target(key as keyof JSX.IntrinsicElements)
-  }
+    return target(key as keyof JSX.IntrinsicElements);
+  },
 }) as StyledFn & {
-  [T in keyof JSX.IntrinsicElements]: StyleTemplate<T>
-}
+  [T in keyof JSX.IntrinsicElements]: StyleTemplate<T>;
+};
 
 export { styled };

--- a/website/src/pages/docs/API/styled.mdx
+++ b/website/src/pages/docs/API/styled.mdx
@@ -64,6 +64,20 @@ export const ThisIsStyledComponent = styled('div')`
 `;
 ```
 
+## Extending styles
+
+You can pass a styled component to the `styled` function to extend styles:
+
+```tsx copy
+const GreenButton = styled.button`
+  background: green;
+`;
+
+const GreenButtonWithRedText = styled(GreenButton)`
+  color: red;
+`;
+```
+
 ## Configuring and Using Breakpoints
 
 The `styled` API also accepts shared media query breakpoints defined in your Kuma configuration (`kuma.config.ts`). For instance, if you have the following configuration:


### PR DESCRIPTION
@poteboy assuming https://github.com/kuma-ui/kuma-ui/pull/342 goes in, this is a follow-on I would like to propose. Another feature from styled-components that's a must-have IMO, especially for anyone migrating an existing repo is extending components:

```tsx
const GreenButton = styled.button`
  background: green;
`;

const GreenButtonWithRedText = styled(GreenButton)`
  color: red;
`;
```

Changes needed:

- update typescript types for the `styled` function to allow passing a `StyledComponent` into it (as well as a couple of helper types needed)
- Update the codegen to emit `<ComponentBeingExtended {...props} className={combinedClassName} />` instead of `<Box as="..."  {...props} className={combinedClassName} />`

I added a test, a usage to the example app, and some docs too.